### PR TITLE
Rename package name from 'trusted-vote' to 'trustedvote'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ script:
   - ./configure --with-boost-libdir=/usr/lib
   - make dist
   - mkdir dist
-  - tar -xvzf trusted-vote-*.tar.gz -C dist --strip-components=1
-  - rm -f trusted-vote-*.tar.gz
+  - tar -xvzf trustedvote-*.tar.gz -C dist --strip-components=1
+  - rm -f trustedvote-*.tar.gz
   - pushd "dist"
   - ./configure --with-boost-libdir=/usr/lib
   - make

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([trusted-vote], [0.1])
+AC_INIT([trustedvote], [0.1])
 AM_INIT_AUTOMAKE([foreign no-define nostdinc subdir-objects -Wall])
 
 AC_CONFIG_MACRO_DIRS([share/autoconf/autoconf])


### PR DESCRIPTION
Rename package name from 'trusted-vote' to 'trustedvote'

Reference: https://github.com/trustedvote/trustedvote/issues/30